### PR TITLE
UX: polish remaining singleton detail sections

### DIFF
--- a/app/views/family_members/_family_member.html.erb
+++ b/app/views/family_members/_family_member.html.erb
@@ -11,6 +11,13 @@
   <td colspan=2><%= t('familymember.comentarios') %>: <%= family_member.comentarios %></td>
 </tr>
 <tr>
-  <td><%= link_to t('helpers.edit'), edit_patient_family_member_path(@patient, family_member), class: "btn btn-outline-primary btn-sm" %></td>
-  <td><%= link_to t('helpers.delete.msg'), patient_family_member_path(@patient,family_member), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %></td>
+  <td colspan=2 class="text-end">
+    <div class="d-inline-flex gap-1 flex-wrap justify-content-end">
+      <%= link_to t('helpers.edit'), edit_patient_family_member_path(@patient, family_member), class: "btn btn-outline-primary btn-sm" %>
+      <%= link_to t('helpers.delete.msg'), patient_family_member_path(@patient, family_member), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %>
+    </div>
+  </td>
+</tr>
+<tr class="detail-divider">
+  <td colspan=2></td>
 </tr>

--- a/app/views/family_members/_familymembers.html.erb
+++ b/app/views/family_members/_familymembers.html.erb
@@ -1,18 +1,17 @@
-<table class="table app-table mb-3 Family Members">
-  <tr><th colspan=2 class="table-light"><%= t('familymember.title') %></th></tr>
-  <tr>
-    <td colspan=2>
-      <strong><%= link_to t('helpers.submit.create', :model => "Familiar"), new_patient_family_member_path(@patient), class: "btn btn-outline-primary btn-sm" %></strong>
-    </td>
-  </tr>
-  <% unless @patient.family_members.empty? %>
-    <%= render @familymembers %>
-  <% end %>
-  <% unless @patient.family_members.empty? %>
-  <tr>
-    <td colspan=2>
-      <strong><%= link_to t('helpers.submit.create', :model => "Familiar"), new_patient_family_member_path(@patient), class: "btn btn-outline-primary btn-sm" %></strong>
-    </td>
-  </tr>
-<% end %>
-</table>
+<div class="card border-0 shadow-sm detail-section-card familymembers">
+  <div class="card-header d-flex justify-content-between align-items-center gap-2">
+    <strong><%= t('familymember.title') %></strong>
+    <%= link_to t('helpers.submit.create', :model => "Familiar"), new_patient_family_member_path(@patient), class: "btn btn-outline-primary btn-sm" %>
+  </div>
+  <div class="table-responsive">
+    <table class="table mb-0 app-table">
+      <tbody>
+        <% unless @patient.family_members.empty? %>
+          <%= render @familymembers %>
+        <% else %>
+          <tr><td class="text-muted">Sin familiares registrados.</td></tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/houses/_house.html.erb
+++ b/app/views/houses/_house.html.erb
@@ -14,10 +14,12 @@
 </tr>
 <tr>
   <td colspan=2>
-    <%= link_to t('helpers.delete.msg'),
-                patient_house_path(@patient,house),
-                :method => :delete,
-                :confirm => t('helpers.delete.conf'),
-                class: "btn btn-outline-danger btn-sm" %>
+    <div class="d-flex justify-content-end">
+      <%= link_to t('helpers.delete.msg'),
+                  patient_house_path(@patient, house),
+                  :method => :delete,
+                  :confirm => t('helpers.delete.conf'),
+                  class: "btn btn-outline-danger btn-sm" %>
+    </div>
   </td>
 </tr>

--- a/app/views/houses/_houseinfo.html.erb
+++ b/app/views/houses/_houseinfo.html.erb
@@ -1,17 +1,21 @@
-<table class="table app-table mb-3 house">
-  <tr>
-    <th colspan=2 class="table-light"><%= t('house.title') %></th>
-  </tr>
-  <tr>
-	<td colspan=2>
-	  <% if @house == nil %>
-	  <%= link_to t('helpers.submit.create', :model => "Informacion de Vivienda"), new_patient_house_path(@patient), class: "btn btn-outline-primary btn-sm" %>
-	  <% else %>
-	  <%= link_to t('helpers.edit'), edit_patient_house_path(@patient, @house), class: "btn btn-outline-primary btn-sm" %>
-	  <% end %>
-	</td>
-  </tr>
-  <% if @house != nil %>
-  <%= render @house %>
-  <% end %>
-</table>
+<div class="card border-0 shadow-sm detail-section-card house">
+  <div class="card-header d-flex justify-content-between align-items-center gap-2">
+    <strong><%= t('house.title') %></strong>
+    <% if @house.nil? %>
+      <%= link_to t('helpers.submit.create', :model => "Informacion de Vivienda"), new_patient_house_path(@patient), class: "btn btn-outline-primary btn-sm" %>
+    <% else %>
+      <%= link_to t('helpers.edit'), edit_patient_house_path(@patient, @house), class: "btn btn-outline-primary btn-sm" %>
+    <% end %>
+  </div>
+  <div class="table-responsive">
+    <table class="table mb-0 app-table">
+      <tbody>
+        <% if @house.nil? %>
+          <tr><td class="text-muted">Sin información de vivienda.</td></tr>
+        <% else %>
+          <%= render @house %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/refclinicas/_refclinica.html.erb
+++ b/app/views/refclinicas/_refclinica.html.erb
@@ -6,5 +6,9 @@
  <tr><td colspan=2><%= t('refclinica.aceptado') %>: <%= refclinica.aceptado %></td></tr>
 <tr><td colspan=2><%= t('refclinica.ayudas') %>: <%= refclinica.ayudas %></td></tr>
 <tr>
-  <td colspan=2><%= link_to t('helpers.delete.msg'), patient_refclinica_path(@patient,@refclinica), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %></td>
+  <td colspan=2>
+    <div class="d-flex justify-content-end">
+      <%= link_to t('helpers.delete.msg'), patient_refclinica_path(@patient, @refclinica), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %>
+    </div>
+  </td>
 </tr>

--- a/app/views/refclinicas/_refclinicainfo.html.erb
+++ b/app/views/refclinicas/_refclinicainfo.html.erb
@@ -1,22 +1,21 @@
-<table class="table app-table mb-3 refclinica">
-  <tr>
-    <th colspan=2 class="table-light">
-      <%= t('refclinica.title') %>
-	</th>
-  </tr>	
-  <tr>
-	<td colspan=2><strong>
-	  <% if @refclinica == nil %>
-	  <%= link_to t('helpers.submit.create', :model => "Referencia Clinica"), new_patient_refclinica_path(@patient), class: "btn btn-outline-primary btn-sm" %>
-	  <% else %>
-	  <%= link_to t('helpers.edit'), edit_patient_refclinica_path(@patient, @refclinica), class: "btn btn-outline-primary btn-sm" %>
-	  <% end %>
-	</strong></td>
-  </tr>
-  <% if @refclinica != nil %>
-  <%= render @refclinica %>
-  <tr>
-    <td colspan=2><%= link_to t('helpers.delete.msg'), patient_refclinica_path(@patient,@refclinica), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %></td>
-  </tr>
-  <% end %>
-</table>
+<div class="card border-0 shadow-sm detail-section-card refclinica">
+  <div class="card-header d-flex justify-content-between align-items-center gap-2">
+    <strong><%= t('refclinica.title') %></strong>
+    <% if @refclinica.nil? %>
+      <%= link_to t('helpers.submit.create', :model => "Referencia Clinica"), new_patient_refclinica_path(@patient), class: "btn btn-outline-primary btn-sm" %>
+    <% else %>
+      <%= link_to t('helpers.edit'), edit_patient_refclinica_path(@patient, @refclinica), class: "btn btn-outline-primary btn-sm" %>
+    <% end %>
+  </div>
+  <div class="table-responsive">
+    <table class="table mb-0 app-table">
+      <tbody>
+        <% if @refclinica.nil? %>
+          <tr><td class="text-muted">Sin referencia clínica.</td></tr>
+        <% else %>
+          <%= render @refclinica %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/socioecos/_socioecoinfo.html.erb
+++ b/app/views/socioecos/_socioecoinfo.html.erb
@@ -1,24 +1,28 @@
-<table class="table app-table mb-3 socioeco">
-  <tr>
-    <th colspan=2 class="table-light">
-      <%= t('socioeco.title') %>
-	</th>
-  </tr>
-  <tr>
-  	<td colspan=2>
-	  <% if @socioeco == nil %>
-	  <%= link_to t('helpers.submit.create', :model => "Informacion Socioeconomica"), new_patient_socioeco_path(@patient), class: "btn btn-outline-primary btn-sm" %>
-	  <% else %>
-	  <%= link_to t('helpers.edit'), edit_patient_socioeco_path(@patient, @socioeco), class: "btn btn-outline-primary btn-sm" %>
-	  <% end %>
-	</td>
-  </tr>
-  <% if @socioeco != nil %>
-  <%= render @socioeco %>
-  <tr>
-    <td colspan=2>
-      <%= link_to t('helpers.delete.msg'), patient_socioeco_path(@patient,@socioeco), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %>	   
-    </td>
-  </tr>
-  <% end %>
-</table>
+<div class="card border-0 shadow-sm detail-section-card socioeco">
+  <div class="card-header d-flex justify-content-between align-items-center gap-2">
+    <strong><%= t('socioeco.title') %></strong>
+    <% if @socioeco.nil? %>
+      <%= link_to t('helpers.submit.create', :model => "Informacion Socioeconomica"), new_patient_socioeco_path(@patient), class: "btn btn-outline-primary btn-sm" %>
+    <% else %>
+      <%= link_to t('helpers.edit'), edit_patient_socioeco_path(@patient, @socioeco), class: "btn btn-outline-primary btn-sm" %>
+    <% end %>
+  </div>
+  <div class="table-responsive">
+    <table class="table mb-0 app-table">
+      <tbody>
+        <% if @socioeco.nil? %>
+          <tr><td class="text-muted">Sin información socioeconómica.</td></tr>
+        <% else %>
+          <%= render @socioeco %>
+          <tr>
+            <td colspan=2>
+              <div class="d-flex justify-content-end">
+                <%= link_to t('helpers.delete.msg'), patient_socioeco_path(@patient, @socioeco), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/subprograms/_subprogram.html.erb
+++ b/app/views/subprograms/_subprogram.html.erb
@@ -39,5 +39,9 @@
   <td></td> 
 </tr>
 <tr>
-  <td colspan=2><%= link_to t('helpers.delete.msg'), volunteer_subprogram_path(@volunteer,@subprogram), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %></td>
+  <td colspan=2>
+    <div class="d-flex justify-content-end">
+      <%= link_to t('helpers.delete.msg'), volunteer_subprogram_path(@volunteer, @subprogram), :method => :delete, :confirm => t('helpers.delete.conf'), class: "btn btn-outline-danger btn-sm" %>
+    </div>
+  </td>
 </tr>

--- a/app/views/subprograms/_subprograminfo.html.erb
+++ b/app/views/subprograms/_subprograminfo.html.erb
@@ -1,19 +1,21 @@
-<table class="table app-table mb-3 subprogram">
-  <tr>
-    <th colspan=3 class="table-light">
-      <%= t('subprogram.title') %>
-	</th>
-  </tr>	
-  <tr>
-	<td colspan=3><strong>
-	  <% if @subprogram == nil %>
-	    <%= link_to t('helpers.submit.create', :model => "Subprogramas"), new_volunteer_subprogram_path(@volunteer), class: "btn btn-outline-primary btn-sm" %>
-	  <% else %>
-	    <%= link_to t('helpers.edit'), edit_volunteer_subprogram_path(@volunteer, @subprogram), class: "btn btn-outline-primary btn-sm" %>
-	  <% end %>
-	</strong></td>
-  </tr>
-  <% if @subprogram != nil %>
-  <%= render @subprogram %>
-  <% end %>
-</table>
+<div class="card border-0 shadow-sm detail-section-card subprogram">
+  <div class="card-header d-flex justify-content-between align-items-center gap-2">
+    <strong><%= t('subprogram.title') %></strong>
+    <% if @subprogram.nil? %>
+      <%= link_to t('helpers.submit.create', :model => "Subprogramas"), new_volunteer_subprogram_path(@volunteer), class: "btn btn-outline-primary btn-sm" %>
+    <% else %>
+      <%= link_to t('helpers.edit'), edit_volunteer_subprogram_path(@volunteer, @subprogram), class: "btn btn-outline-primary btn-sm" %>
+    <% end %>
+  </div>
+  <div class="table-responsive">
+    <table class="table mb-0 app-table">
+      <tbody>
+        <% if @subprogram.nil? %>
+          <tr><td class="text-muted">Sin subprogramas configurados.</td></tr>
+        <% else %>
+          <%= render @subprogram %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/volunteers/_socialservice.html.erb
+++ b/app/views/volunteers/_socialservice.html.erb
@@ -1,17 +1,23 @@
-<table class="table app-table mb-3">
-  <tr>
-  	<th colspan=2 class="table-light"><%= t('volunteer.ss') %></th>
-  </tr>
-  <tr>
-    <td><%= t('volunteer.escuela') %>: <%= @volunteer.socialservices.first.escuela %></td>
-    <td><%= t('volunteer.carrera') %>: <%= @volunteer.socialservices.first.carrera %></td>
-  </tr>
-  <tr>
-    <td><%= t('volunteer.matricula') %>: <%= @volunteer.socialservices.first.matricula %></td>
-    <td><%= t('volunteer.semestre') %>: <%= @volunteer.socialservices.first.semestre %></td>
-  </tr>
-  <tr>
-    <td><%= t('volunteer.inicio') %>: <%= l @volunteer.socialservices.first.inicio %></td>
-    <td><%= t('volunteer.fin') %>: <%= l @volunteer.socialservices.first.fin %></td>
-  </tr> 
-</table>
+<div class="card border-0 shadow-sm detail-section-card volunteer-socialservice">
+  <div class="card-header">
+    <strong><%= t('volunteer.ss') %></strong>
+  </div>
+  <div class="table-responsive">
+    <table class="table mb-0 app-table">
+      <tbody>
+        <tr>
+          <td><%= t('volunteer.escuela') %>: <%= @volunteer.socialservices.first.escuela %></td>
+          <td><%= t('volunteer.carrera') %>: <%= @volunteer.socialservices.first.carrera %></td>
+        </tr>
+        <tr>
+          <td><%= t('volunteer.matricula') %>: <%= @volunteer.socialservices.first.matricula %></td>
+          <td><%= t('volunteer.semestre') %>: <%= @volunteer.socialservices.first.semestre %></td>
+        </tr>
+        <tr>
+          <td><%= t('volunteer.inicio') %>: <%= l @volunteer.socialservices.first.inicio %></td>
+          <td><%= t('volunteer.fin') %>: <%= l @volunteer.socialservices.first.fin %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- convert remaining singleton/detail sections to the shared Bootstrap card + table shell
- update `familymembers`, `house`, `refclinica`, `subprogram`, `socioeco`, and volunteer `socialservice` sections
- standardize action placement to right-aligned grouped controls
- remove the last legacy section wrappers from these partials

## Validation
- `CHROMEDRIVER_PATH="$(command -v chromedriver)" DISABLE_SPRING=1 bundle exec rspec spec/system/patients_spec.rb spec/system/volunteers_spec.rb spec/system/users_spec.rb`
- `CHROMEDRIVER_PATH="$(command -v chromedriver)" DISABLE_SPRING=1 bundle exec rspec -f j -o rspec_ux_polish_pass4_remaining_singletons.json` (571 examples, 0 failures, 79 pending)
